### PR TITLE
Fix errors in plugin definition

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,6 @@
     "extra": {
         "name": "Gatsby",
         "handle": "gatsby",
-        "developerUrl": "https://craftcms.com/",
+        "developerUrl": "https://craftcms.com/"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,6 @@
         "name": "Gatsby",
         "handle": "gatsby",
         "developerUrl": "https://craftcms.com/",
-        "class": "craftcms\\craft-gatsby\\Gatsby",
+        "class": "craftcms\\craft-gatsby\\Gatsby"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
     "extra": {
         "name": "Gatsby",
         "handle": "gatsby",
-        "developerUrl": "https://craftcms.com/"
+        "developerUrl": "https://craftcms.com/",
+        "class": "craftcms\\craft-gatsby\\Gatsby",
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,6 @@
         "name": "Gatsby",
         "handle": "gatsby",
         "developerUrl": "https://craftcms.com/",
-        "class": "craftcms\\craft-gatsby\\Gatsby"
+        "class": "craftcms\\gatsby\\Gatsby"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,6 @@
     "extra": {
         "name": "Gatsby",
         "handle": "gatsby",
-        "developerUrl": "https://craftcms.com/",
-        "class": "craftcms\\gatsby\\Gatsby"
+        "developerUrl": "https://craftcms.com/"
     }
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -11,7 +11,6 @@
 namespace craft\gatsby;
 
 use craft\base\Element;
-use craft\base\Plugin;
 use craft\events\RegisterGqlQueriesEvent;
 use craft\events\RegisterGqlSchemaComponentsEvent;
 use craft\gatsby\gql\queries\Sourcing as SourcingDataQueries;
@@ -35,7 +34,7 @@ use yii\base\Event;
  *
  * @property  SourceNodes $data
  */
-class Gatsby extends Plugin
+class Plugin extends \craft\base\Plugin
 {
     // Static Properties
     // =========================================================================

--- a/src/gql/queries/Sourcing.php
+++ b/src/gql/queries/Sourcing.php
@@ -8,7 +8,7 @@
 namespace craft\gatsby\gql\queries;
 
 use Craft;
-use craft\gatsby\Gatsby;
+use craft\gatsby\Plugin as Gatsby;
 use craft\gatsby\gql\resolvers\SourceNode as SourceNodeResolver;
 use craft\gatsby\gql\resolvers\UpdatedNode as UpdatedNodeResolver;
 use craft\gatsby\gql\resolvers\DeletedNode as DeletedNodeResolver;

--- a/src/gql/resolvers/DeletedNode.php
+++ b/src/gql/resolvers/DeletedNode.php
@@ -9,7 +9,7 @@ namespace craft\gatsby\gql\resolvers;
 
 use Craft;
 use craft\gql\base\Resolver;
-use craft\gatsby\Gatsby;
+use craft\gatsby\Plugin as Gatsby;
 use GraphQL\Type\Definition\ResolveInfo;
 
 /**

--- a/src/gql/resolvers/SourceNode.php
+++ b/src/gql/resolvers/SourceNode.php
@@ -8,7 +8,7 @@
 namespace craft\gatsby\gql\resolvers;
 
 use craft\gql\base\Resolver;
-use craft\gatsby\Gatsby;
+use craft\gatsby\Plugin as Gatsby;
 use GraphQL\Type\Definition\ResolveInfo;
 
 /**

--- a/src/gql/resolvers/UpdatedNode.php
+++ b/src/gql/resolvers/UpdatedNode.php
@@ -9,7 +9,7 @@ namespace craft\gatsby\gql\resolvers;
 
 use Craft;
 use craft\gql\base\Resolver;
-use craft\gatsby\Gatsby;
+use craft\gatsby\Plugin as Gatsby;
 use GraphQL\Type\Definition\ResolveInfo;
 
 /**


### PR DESCRIPTION
### Description

There was a trailing slash at the end of the `extra` attributes that meant the `composer.json` was invalid and unable to be parsed when trying to install the plugin via composer.

Also, the class definition for the plugin was missing.