### PR TITLE
fix: preview token retrieval for craft 4

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -255,7 +255,11 @@ class Plugin extends \craft\base\Plugin
                                 };
                                 
                                 if (doPreview) {
-                                    payload.token = await event.target.draftEditor.getPreviewToken();
+                                    if(event.target.elementEditor) {
+                                        payload.token = await event.target.elementEditor.getPreviewToken();
+                                    } else {
+                                        payload.token = await event.target.draftEditor.getPreviewToken();
+                                    }
                                 } else {
                                     currentlyPreviewing = null;
                                 }


### PR DESCRIPTION
### Description

Craft 4 uses "elementEditor" instead of "draftEditor". Running a preview with this plugin would cause an undefined error when accessing this variable, preventing proper previews from being triggered on draft content changes.

This pull request allows the script to work with both `elementEditor` and `draftEditor`.

### Related issues

I couldn't find an issue for this particular bug.
