### PR TITLE
Update Plugin.php

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -255,7 +255,7 @@ class Plugin extends \craft\base\Plugin
                                 };
                                 
                                 if (doPreview) {
-                                    payload.token = await event.target.draftEditor.getPreviewToken();
+                                    payload.token = await event.target.elementEditor.getPreviewToken();
                                 } else {
                                     currentlyPreviewing = null;
                                 }


### PR DESCRIPTION
### Description
`Craft.draftEditor` was removed in 4.0. This updates the plugin to use the new `elementEditor` method. 

