### PR TITLE
respect schema permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release Notes for Gatsby Helper
 
+## Unreleased
+- Fixed an error that could occur when determining which elements had been updated when sourcing elements. ([#31](https://github.com/craftcms/gatsby-helper/issues/31))
+
 ## 1.1.3 - 2021-04-13
 
 ### Changed


### PR DESCRIPTION
### Description
When getting `nodesUpdatedSince` and encountering an element not allowed by the GQL schema, log the error and skip over to the next element instead of throwing an exception and bailing. 

I also added an additional safeguard if the element wasn’t found by its ID.

(Tested against v1 and v2.)


### Related issues
#31 
